### PR TITLE
Add RTS (Request To Send) Handshake

### DIFF
--- a/SerialMonitor.cs
+++ b/SerialMonitor.cs
@@ -25,6 +25,7 @@ namespace NintendoSpy
         {
             _localBuffer = new List <byte> ();
             _datPort = new SerialPort (portName, BAUD_RATE);
+            _datPort.Handshake = Handshake.RequestToSend
         }
 
         public void Start ()

--- a/SerialMonitor.cs
+++ b/SerialMonitor.cs
@@ -25,7 +25,7 @@ namespace NintendoSpy
         {
             _localBuffer = new List <byte> ();
             _datPort = new SerialPort (portName, BAUD_RATE);
-            _datPort.Handshake = Handshake.RequestToSend
+            _datPort.Handshake = Handshake.RequestToSend;
         }
 
         public void Start ()


### PR DESCRIPTION
Some Arduino/clones/serial devices use an optional mechanism (of 802.11 wireless networking protocol) to reduce frame collisions. I don't know why only some devices require it, but I was able to get a Sparkfun Pro Micro atmega32u4 clone to work by adding this line. 

I found someone who had a similar problem here:
https://www.visualmicro.com/forums/YaBB.pl?num=1531953781