### PR TITLE
Update SerialMonitor.cs to support Atmel 32u4 Boards

### DIFF
--- a/SerialMonitor.cs
+++ b/SerialMonitor.cs
@@ -26,6 +26,7 @@ namespace NintendoSpy
             _localBuffer = new List <byte> ();
             _datPort = new SerialPort (portName, BAUD_RATE);
             _datPort.Handshake = Handshake.RequestToSend;
+            _datPort.DtrEnable = true;
         }
 
         public void Start ()


### PR DESCRIPTION
Had to redo everything^^

DtrEnable to Support Atmel 32u4 Boards like the Leonardo, Sparkfun Pro Micro etc.